### PR TITLE
different docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
 FROM jupyter/datascience-notebook:python-3.7.6
+
+# Add RUN statements to install packages as the $NB_USER defined in the base images.
+
+# Add a "USER root" statement followed by RUN statements to install system packages using apt-get,
+# change file permissions, etc.
+
+# If you do switch to root, always be sure to add a "USER $NB_USER" command at the end of the
+# file to ensure the image runs as a unprivileged user by default.
+
+USER $NB_UID
+
 WORKDIR work
+
 COPY requirements.txt .
+
 RUN pip install -r requirements.txt
-COPY . .
-RUN python ./setup.py install
+
 USER root
-RUN chmod -R 777 *
-RUN pip install flair
+
+COPY . .
+
+EXPOSE 8888
+
+RUN python ./setup.py install
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER $NB_UID

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN pip install -r requirements.txt
 
 USER root
 
+RUN chmod -R 777 *
+
 COPY . .
 
 EXPOSE 8888

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-2.2.5
 regex
 #azureml
 #azureml-sdk
-#flair
+flair
 sklearn_crfsuite
 pytest


### PR DESCRIPTION
with this set up, all requirements stay in `requirements.txt`  and you avoid `chmod -R 777 *`: you can bind-mounting your local working directory to the working directory in the docker container: 

`docker run -p 8888:8888 -v ~/code/data-science/presidio-research:/home/jovyan/work --name presidio bdolor/presidio-research:1.0`